### PR TITLE
feat(hitToParams): Allow to return an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,12 @@ function init({ algoliaConfig, sitemapLocation, hitToParams }) {
     if (!hits) {
       return;
     }
-    const entries = hits.map(hitToParams).filter(Boolean);
-    batch = batch.concat(entries);
+    batch = batch.concat(
+      hits.reduce((entries, hit) => {
+        const entry = hitToParams(hit);
+        return entry ? entries.concat(entry) : entries;
+      }, [])
+    );
     if (batch.length > CHUNK_SIZE) {
       flush();
     }


### PR DESCRIPTION
The hitToParams callback can now return an array of params. This allows
to handle cases where hits have multiple categories.