### PR TITLE
fix(sitemap): validate and parse properties

### DIFF
--- a/__tests__/__snapshots__/sitemap.js.snap
+++ b/__tests__/__snapshots__/sitemap.js.snap
@@ -50,7 +50,8 @@ exports[`sitemap renders with multiple optional entries 1`] = `
   <url>
     <loc>https://www.example.com</loc>
     <lastmod>1970-01-01T00:00:00.001Z</lastmod>
-    <changefreq>daily</changefreq>0
+    <changefreq>daily</changefreq>
+    <priority>0</priority>
   </url>
   <url>
     <loc>https://www.example.com/test</loc>

--- a/__tests__/__snapshots__/sitemap.js.snap
+++ b/__tests__/__snapshots__/sitemap.js.snap
@@ -51,7 +51,7 @@ exports[`sitemap renders with multiple optional entries 1`] = `
     <loc>https://www.example.com</loc>
     <lastmod>1970-01-01T00:00:00.001Z</lastmod>
     <changefreq>daily</changefreq>
-    <priority>0</priority>
+    <priority>0.0</priority>
   </url>
   <url>
     <loc>https://www.example.com/test</loc>

--- a/__tests__/sitemap.js
+++ b/__tests__/sitemap.js
@@ -61,6 +61,20 @@ describe('sitemap', () => {
       });
     });
 
+    it('ensures lastmod is a w3c date', () => {
+      [
+        { loc: 'https://example.com', lastmod: '' },
+        { loc: 'https://example.com', lastmod: '15 august' },
+        { loc: 'https://example.com', lastmod: new Date(1) },
+        { loc: 'https://example.com', lastmod: new Date(1).toString() },
+        { loc: 'https://example.com', lastmod: new Date(1).toDateString() },
+      ].forEach(entry => {
+        expect(() => {
+          createSitemap([entry]);
+        }).toThrow();
+      });
+    });
+
     it('ensures priority is between 0 and 1', () => {
       [
         {

--- a/__tests__/sitemap.js
+++ b/__tests__/sitemap.js
@@ -41,6 +41,20 @@ describe('sitemap', () => {
     expect(sitemap.stringify()).toMatchSnapshot();
   });
 
+  it('renders with alternatives', () => {
+    const entries = [
+      {
+        loc: 'https://www.example.com',
+        alternates: {
+          languages: ['en', 'fr'],
+          hitToURL: lang => `https://${lang}.example.com`,
+        },
+      },
+    ];
+    const sitemap = createSitemap(entries);
+    expect(sitemap.stringify()).toMatchSnapshot();
+  });
+
   describe('Validation', () => {
     it('ensures loc is required', () => {
       [
@@ -117,20 +131,32 @@ describe('sitemap', () => {
         }).toThrow();
       });
     });
-  });
 
-  it('renders with alternatives', () => {
-    const entries = [
-      {
-        loc: 'https://www.example.com',
-        alternates: {
-          languages: ['en', 'fr'],
-          hitToURL: lang => `https://${lang}.example.com`,
+    it('ensures alternates are returning urls', () => {
+      [
+        {
+          loc: 'https://www.example.com/test',
+          alternates: {},
         },
-      },
-    ];
-    const sitemap = createSitemap(entries);
-    expect(sitemap.stringify()).toMatchSnapshot();
+        {
+          loc: 'https://www.example.com/test',
+          alternates: {
+            languages: '',
+          },
+        },
+        {
+          loc: 'https://www.example.com/test',
+          alternates: {
+            languages: [''],
+            hitToURL: () => 'invalid url',
+          },
+        },
+      ].forEach(entry => {
+        expect(() => {
+          createSitemap([entry]);
+        }).toThrow();
+      });
+    });
   });
 });
 

--- a/__tests__/sitemap.js
+++ b/__tests__/sitemap.js
@@ -44,28 +44,67 @@ describe('sitemap', () => {
     expect(str(sitemap)).toMatchSnapshot();
   });
 
-  it(`Ensures priority is between 0 and 1`, () => {
-    [
-      {
-        loc: 'https://www.example.com/test',
-        priority: NaN,
-      },
-      {
-        loc: 'https://www.example.com/test',
-        priority: '0',
-      },
-      {
-        loc: 'https://www.example.com/test',
-        priority: -5,
-      },
-      {
-        loc: 'https://www.example.com/test',
-        priority: 1.1,
-      },
-    ].forEach(entry => {
-      expect(() => {
-        createSitemap([entry]);
-      }).toThrow();
+  describe('Validation', () => {
+    it('ensures loc is required', () => {
+      [
+        {},
+        {
+          changefreq: 'weekly',
+        },
+        {
+          alternates: [],
+        },
+      ].forEach(entry => {
+        expect(() => {
+          createSitemap([entry]);
+        }).toThrow();
+      });
+    });
+
+    it('ensures priority is between 0 and 1', () => {
+      [
+        {
+          loc: 'https://www.example.com/test',
+          priority: NaN,
+        },
+        {
+          loc: 'https://www.example.com/test',
+          priority: '0',
+        },
+        {
+          loc: 'https://www.example.com/test',
+          priority: -5,
+        },
+        {
+          loc: 'https://www.example.com/test',
+          priority: 1.1,
+        },
+      ].forEach(entry => {
+        expect(() => {
+          createSitemap([entry]);
+        }).toThrow();
+      });
+    });
+
+    it('ensures changefreq follows spec', () => {
+      [
+        {
+          loc: 'https://www.example.com/test',
+          changefreq: 'WEEKLY',
+        },
+        {
+          loc: 'https://www.example.com/test',
+          changefreq: '0',
+        },
+        {
+          loc: 'https://www.example.com/test',
+          changefreq: null,
+        },
+      ].forEach(entry => {
+        expect(() => {
+          createSitemap([entry]);
+        }).toThrow();
+      });
     });
   });
 

--- a/__tests__/sitemap.js
+++ b/__tests__/sitemap.js
@@ -44,6 +44,31 @@ describe('sitemap', () => {
     expect(str(sitemap)).toMatchSnapshot();
   });
 
+  it(`Ensures priority is between 0 and 1`, () => {
+    [
+      {
+        loc: 'https://www.example.com/test',
+        priority: NaN,
+      },
+      {
+        loc: 'https://www.example.com/test',
+        priority: '0',
+      },
+      {
+        loc: 'https://www.example.com/test',
+        priority: -5,
+      },
+      {
+        loc: 'https://www.example.com/test',
+        priority: 1.1,
+      },
+    ].forEach(entry => {
+      expect(() => {
+        createSitemap([entry]);
+      }).toThrow();
+    });
+  });
+
   it('renders with alternatives', () => {
     const entries = [
       {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "algoliasearch": "^3.22.1",
-    "jsx-string": "^2.0.0"
+    "jsx-string": "^2.0.0",
+    "validator": "^7.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/sitemap.js
+++ b/sitemap.js
@@ -22,8 +22,6 @@ function createSitemapindex(sitemaps = []) {
   };
 }
 
-const notNull = item => item !== null && item !== undefined;
-
 function createSitemap(entries = []) {
   const _alternates = ({ languages, hitToURL }) =>
     languages
@@ -37,7 +35,7 @@ function createSitemap(entries = []) {
       <loc>{loc}</loc>
       {lastmod && <lastmod>{lastmod}</lastmod>}
       {changefreq && <changefreq>{changefreq}</changefreq>}
-      {notNull(priority) ? <priority>{priority}</priority> : null}
+      {Number.isFinite(priority) ? <priority>{priority}</priority> : null}
       {alternates && _alternates(alternates)}
     </url>
   );

--- a/sitemap.js
+++ b/sitemap.js
@@ -22,6 +22,8 @@ function createSitemapindex(sitemaps = []) {
   };
 }
 
+const notNull = item => item !== null && item !== undefined;
+
 function createSitemap(entries = []) {
   const _alternates = ({ languages, hitToURL }) =>
     languages
@@ -35,7 +37,7 @@ function createSitemap(entries = []) {
       <loc>{loc}</loc>
       {lastmod && <lastmod>{lastmod}</lastmod>}
       {changefreq && <changefreq>{changefreq}</changefreq>}
-      {priority && <priority>{priority}</priority>}
+      {notNull(priority) ? <priority>{priority}</priority> : null}
       {alternates && _alternates(alternates)}
     </url>
   );

--- a/sitemap.js
+++ b/sitemap.js
@@ -22,6 +22,28 @@ function createSitemapindex(sitemaps = []) {
   };
 }
 
+const isValidURL = ({ loc, lastmod, changefreq, priority, alternates }) => {
+  if (
+    priority < 0 ||
+    priority > 1 ||
+    (!Number.isFinite(priority) && priority !== undefined)
+  ) {
+    throw new Error(
+      `priority "${priority}" was not valid. A number between 0 and 1 is expected.
+
+see https://www.sitemaps.org/protocol.html for more information`
+    );
+  }
+
+  return {
+    loc,
+    lastmod,
+    changefreq,
+    priority: priority === undefined ? undefined : priority.toFixed(1),
+    alternates,
+  };
+};
+
 function createSitemap(entries = []) {
   const _alternates = ({ languages, hitToURL }) =>
     languages
@@ -30,15 +52,26 @@ function createSitemap(entries = []) {
         <xhtml_link rel="alternate" hreflang={language} href={href} />
       ));
 
-  const url = ({ loc, lastmod, changefreq, priority, alternates }) => (
-    <url xmlns_xhtml={alternates ? 'http://www.w3.org/1999/xhtml' : undefined}>
-      <loc>{loc}</loc>
-      {lastmod && <lastmod>{lastmod}</lastmod>}
-      {changefreq && <changefreq>{changefreq}</changefreq>}
-      {Number.isFinite(priority) ? <priority>{priority}</priority> : null}
-      {alternates && _alternates(alternates)}
-    </url>
-  );
+  const url = args => {
+    const {
+      loc = undefined,
+      lastmod = undefined,
+      changefreq = undefined,
+      priority = undefined,
+      alternates = undefined,
+    } = isValidURL(args);
+    return (
+      <url
+        xmlns_xhtml={alternates ? 'http://www.w3.org/1999/xhtml' : undefined}
+      >
+        <loc>{loc}</loc>
+        {lastmod && <lastmod>{lastmod}</lastmod>}
+        {changefreq && <changefreq>{changefreq}</changefreq>}
+        {priority && <priority>{priority}</priority>}
+        {alternates && _alternates(alternates)}
+      </url>
+    );
+  };
 
   const sitemap = (
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/sitemap.js
+++ b/sitemap.js
@@ -23,6 +23,35 @@ function createSitemapindex(sitemaps = []) {
 }
 
 const isValidURL = ({ loc, lastmod, changefreq, priority, alternates }) => {
+  // loc
+  if (!loc) {
+    throw new Error(`loc "${loc}" was not valid. It's required.`);
+  }
+
+  // lastmod
+
+  // changefreq
+  const allowedFreqs = [
+    'always',
+    'hourly',
+    'daily',
+    'weekly',
+    'monthly',
+    'yearly',
+    'never',
+  ];
+
+  if (!allowedFreqs.includes(changefreq) && changefreq !== undefined) {
+    throw new Error(
+      `changefreq "${changefreq}" was not a valid value.
+
+expected: ${allowedFreqs.join(', ')}
+
+see https://www.sitemaps.org/protocol.html for more information`
+    );
+  }
+
+  // priority
   if (
     priority < 0 ||
     priority > 1 ||

--- a/sitemap.js
+++ b/sitemap.js
@@ -1,4 +1,5 @@
 const jsxString = require('jsx-string');
+const validator = require('validator');
 
 const XML = content =>
   `<?xml version="1.0" encoding="utf-8"?>${jsxString(content)}`;
@@ -24,11 +25,25 @@ function createSitemapindex(sitemaps = []) {
 
 const isValidURL = ({ loc, lastmod, changefreq, priority, alternates }) => {
   // loc
-  if (!loc) {
-    throw new Error(`loc "${loc}" was not valid. It's required.`);
+  if (!loc && !validator.isURL(loc, { require_valid_protocol: true })) {
+    throw new Error(
+      `loc "${loc}" was not valid. It's required.
+
+see https://www.sitemaps.org/protocol.html`
+    );
   }
 
   // lastmod
+  if (lastmod !== undefined && !validator.isISO8601(lastmod)) {
+    throw new Error(
+      `lastmod "${lastmod}" is not valid. It should be a valid ISO 8601 date
+
+Try using new Date().toISOString()
+
+see https://www.sitemaps.org/protocol.html
+see https://www.w3.org/TR/NOTE-datetime`
+    );
+  }
 
   // changefreq
   const allowedFreqs = [

--- a/sitemap.js
+++ b/sitemap.js
@@ -79,6 +79,30 @@ see https://www.sitemaps.org/protocol.html for more information`
     );
   }
 
+  // alternates
+  const _alternatesError = `alternates ${JSON.stringify(alternates)} was not valid. An object with
+
+{
+  languages: ['nl-BE', 'fr', 'pt-BR'],
+  hitToURL: (language) => \`the url for that \${language}\`,
+}
+
+was expected.`;
+
+  if (alternates !== undefined) {
+    if (!(alternates.languages instanceof Array)) {
+      throw new Error(_alternatesError);
+    }
+    if (typeof alternates.hitToURL !== 'function') {
+      throw new Error(_alternatesError);
+    }
+    alternates.languages.forEach(lang => {
+      if (!validator.isURL(alternates.hitToURL(lang))) {
+        throw new Error(_alternatesError);
+      }
+    });
+  }
+
   return {
     loc,
     lastmod,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,6 +3643,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+validator@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-7.0.0.tgz#c74deb8063512fac35547938e6f0b1504a282fd2"
+
 verror@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"


### PR DESCRIPTION
The goal of this PR is to validate which values for the options are valid. I based myself on https://www.sitemaps.org/protocol.html

I was doubting to add a typing system, but I’m not sure if that would catch the need of having descriptive error messages.

## sidenote

before, because of using `&&` instead of checking `undefined` and `null`, a 0 given to priority would not be wrapped in its tag.

I noticed this change when updating the snapshots in #15