### PR TITLE
feat: specify query and search params

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ const algoliaSitemap = require('algolia-sitemap');
 
 algoliaSitemap({
   algoliaConfig,
-  sitemapLocation: { href: 'https://yoursite.com/sitemaps', path: 'sitemaps' },
+  sitemapLoc: 'https://yoursite.com/sitemaps'
+  outputFolder: 'sitemaps',
   hitToParams,
 });
 ```
@@ -81,7 +82,27 @@ These parameters mean:
  */
 ```
 
-You can also take a look at `examples` folder for how this works.
+## Custom queries
+You can pass a `query` and a `params` parameter to `algoliaSitemap`. This allows you to narrow down the returned results.
+For instance, in order to have `hitToParams` called for every products in the `phone` category, we could do:
+
+```js
+algoliaSitemap({
+  algoliaConfig,
+  sitemapLoc: 'https://yoursite.com/sitemaps'
+  outputFolder: 'sitemaps',
+  params: {
+    filters: 'category: phone'
+  }
+  hitToParams,
+});
+```
+
+## Examples
+You can also take a look at `examples` folder for how it works.
+
+* To generate a sitemap of all the hits in an index, check the [detail pages example](examples/details)
+* To generate a sitemap of all the category pages, check the [category pages example](examples/category)
 
 # License 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ These parameters mean:
 ```
 
 ## Custom queries
-You can pass a `query` and a `params` parameter to `algoliaSitemap`. This allows you to narrow down the returned results.
+You can pass a `params` parameter to `algoliaSitemap`. This allows you to narrow down the returned results.
 For instance, in order to have `hitToParams` called for every products in the `phone` category, we could do:
 
 ```js
@@ -97,6 +97,8 @@ algoliaSitemap({
   hitToParams,
 });
 ```
+
+Note that a query can also be passed to `params`.
 
 ## Examples
 You can also take a look at `examples` folder for how it works.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ let batch = [];
 
 function init({
   algoliaConfig,
-  query,
   params,
   sitemapLoc,
   outputFolder,
@@ -69,7 +68,7 @@ function init({
     });
   };
 
-  return index.browse(query, params).then(aggregator);
+  return index.browse(params).then(aggregator);
 }
 
 module.exports = init;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,14 @@ const CHUNK_SIZE = 50000;
 
 let batch = [];
 
-function init({ algoliaConfig, sitemapLoc, outputFolder, hitToParams }) {
+function init({
+  algoliaConfig,
+  query,
+  params,
+  sitemapLoc,
+  outputFolder,
+  hitToParams,
+}) {
   const client = algoliasearch(algoliaConfig.appId, algoliaConfig.apiKey);
   const index = client.initIndex(algoliaConfig.indexName);
   const sitemaps = [];
@@ -62,7 +69,7 @@ function init({ algoliaConfig, sitemapLoc, outputFolder, hitToParams }) {
     });
   };
 
-  return index.browse().then(aggregator);
+  return index.browse(query, params).then(aggregator);
 }
 
 module.exports = init;


### PR DESCRIPTION
This one refers to #2. It makes it possible to a `query` and a `params` parameter to `algoliaSitemap`.