### PR TITLE
Close #107. Add Google Image Sitemap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These parameters mean:
  * @property {number} [priority] the priority you give to this link (between 0 and 1)
  * @property {Object} [alternates] alternative versions of this link (useful for multi-language)
  * @property {Array} [alternates.languages] list of languages that are enabled
- * @property {Array} [images] list of images links related to the hit.
+ * @property {Array} [images] list of images links related to the hit
  * @property {function} [alternates.hitToURL] function to transform a language into a url of this object
  */
 ```

--- a/README.md
+++ b/README.md
@@ -78,9 +78,65 @@ These parameters mean:
  * @property {number} [priority] the priority you give to this link (between 0 and 1)
  * @property {Object} [alternates] alternative versions of this link (useful for multi-language)
  * @property {Array} [alternates.languages] list of languages that are enabled
+ * @property {Array} [images] list of images links related to the hit.
  * @property {function} [alternates.hitToURL] function to transform a language into a url of this object
  */
 ```
+
+### Image Sitemaps
+
+If you want your sitemap to include [Google image extensions](https://support.google.com/webmasters/answer/178636?hl=en), return an array for each hit containing objects with the following keys:
+
+```js
+/**
+ * @typedef {Object} Image
+ * @property {string} loc the link of this image
+ * @property {string} [title] image title
+ * @property {string} [caption] image caption
+ * @property {string} [geo_location] geographic location (e.g. 'Limerick, Ireland')
+ * @property {string} [license] the link to the image's license
+ */
+```
+
+For example:
+
+```js
+function hitToParams({
+  objectID,
+  modified,
+  downloadsRatio,
+  profilePic,
+  coverPhoto,
+  name,
+}) {
+  const url = ({ lang, objectID }) =>
+    `https://${lang}.yoursite.com/${lang}/detail/${objectID}`;
+  const loc = url({ lang: 'en', objectID });
+  const lastmod = new Date().toISOString();
+  const priority = Math.random();
+  return {
+    loc,
+    lastmod,
+    priority,
+    images: [
+      {
+        loc: `https://media.yoursite.com/images/${profilePic}`,
+        title: name,
+      },
+      {
+        loc: `https://media.yoursite.com/images/${coverPhoto}`,
+        title: name,
+      },
+    ],
+    alternates: {
+      languages: ['fr', 'pt-BR', 'zh-Hans'],
+      hitToURL: lang => url({ lang, objectID }),
+    },
+  };
+}
+```
+
+For more information, see https://support.google.com/webmasters/answer/178636?hl=en
 
 ## Custom queries
 

--- a/__tests__/__snapshots__/sitemap.js.snap
+++ b/__tests__/__snapshots__/sitemap.js.snap
@@ -144,7 +144,9 @@ exports[`sitemap renders empty if needed 1`] = `
 <?xml version="1.0"
       encoding="utf-8"
 ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+>
 </urlset>
 
 `;
@@ -154,7 +156,9 @@ exports[`sitemap renders with a single loc-only entry 1`] = `
 <?xml version="1.0"
       encoding="utf-8"
 ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+>
   <url>
     <loc>
       https://www.example.com
@@ -169,7 +173,9 @@ exports[`sitemap renders with alternatives 1`] = `
 <?xml version="1.0"
       encoding="utf-8"
 ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+>
   <url xmlns:xhtml="http://www.w3.org/1999/xhtml">
     <loc>
       https://www.example.com
@@ -189,12 +195,74 @@ exports[`sitemap renders with alternatives 1`] = `
 
 `;
 
+exports[`sitemap renders with images 1`] = `
+
+<?xml version="1.0"
+      encoding="utf-8"
+?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+>
+  <url>
+    <loc>
+      https://www.example.com
+    </loc>
+    <image:image>
+      <image:loc>
+        https://www.example.com/hero.jpg
+      </image:loc>
+      <image:title>
+        hero test
+      </image:title>
+    </image:image>
+    <image:image>
+      <image:loc>
+        https://www.example.com/caption.png
+      </image:loc>
+      <image:caption>
+        caption test
+      </image:caption>
+    </image:image>
+  </url>
+  <url>
+    <loc>
+      https://www.example.com/test
+    </loc>
+    <image:image>
+      <image:loc>
+        https://www.example.com/test.jpg
+      </image:loc>
+      <image:title>
+        test
+      </image:title>
+    </image:image>
+    <image:image>
+      <image:loc>
+        https://www.example.com/empire.jpg
+      </image:loc>
+      <image:title>
+        Empire State Building
+      </image:title>
+      <image:geo_location>
+        New York, New York
+      </image:geo_location>
+      <image:license>
+        https://raw.githubusercontent.com/algolia/algolia-sitemap/master/LICENSE
+      </image:license>
+    </image:image>
+  </url>
+</urlset>
+
+`;
+
 exports[`sitemap renders with multiple loc-only entries 1`] = `
 
 <?xml version="1.0"
       encoding="utf-8"
 ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+>
   <url>
     <loc>
       https://www.example.com
@@ -214,7 +282,9 @@ exports[`sitemap renders with multiple optional entries 1`] = `
 <?xml version="1.0"
       encoding="utf-8"
 ?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+>
   <url>
     <loc>
       https://www.example.com

--- a/__tests__/sitemap.js
+++ b/__tests__/sitemap.js
@@ -22,6 +22,37 @@ describe('sitemap', () => {
     expect(sitemap.stringify()).toMatchSnapshot();
   });
 
+  it('renders with images', () => {
+    const entries = [
+      {
+        loc: 'https://www.example.com',
+        images: [
+          { loc: 'https://www.example.com/hero.jpg', title: 'hero test' },
+          {
+            loc: 'https://www.example.com/caption.png',
+            caption: 'caption test',
+          },
+        ],
+      },
+      {
+        loc: 'https://www.example.com/test',
+        images: [
+          { loc: 'https://www.example.com/test.jpg', title: 'test' },
+          {
+            loc: 'https://www.example.com/empire.jpg',
+            title: 'Empire State Building',
+            // eslint-disable-next-line
+            geo_location: 'New York, New York',
+            license:
+              'https://raw.githubusercontent.com/algolia/algolia-sitemap/master/LICENSE',
+          },
+        ],
+      },
+    ];
+    const sitemap = createSitemap(entries);
+    expect(sitemap.stringify()).toMatchSnapshot();
+  });
+
   it('renders with multiple optional entries', () => {
     const entries = [
       {

--- a/sitemap.js
+++ b/sitemap.js
@@ -215,24 +215,10 @@ function createSitemap(entries = []) {
         // it can only do this for self-closing tags (i.e. without children), thus we augment some XML output
         // with regex/string magic.
         //
-        // <image:image></image:image>
-        .replace(/<imageimage>/g, '<image:image>')
-        .replace(/<\/imageimage>/g, '</image:image>')
-        // <image:loc></image:loc>
-        .replace(/<imageloc>/g, '<image:loc>')
-        .replace(/<\/imageloc>/g, '</image:loc>')
-        // <image:caption></image:caption>
-        .replace(/<imagecaption>/g, '<image:caption>')
-        .replace(/<\/imagecaption>/g, '</image:caption>')
-        // <image:title></image:title>
-        .replace(/<imagetitle>/g, '<image:title>')
-        .replace(/<\/imagetitle>/g, '</image:title>')
-        // <image:geo_location></image:geo_location>
-        .replace(/<imagegeolocation>/g, '<image:geo_location>')
-        .replace(/<\/imagegeolocation>/g, '</image:geo_location>')
-        // <image:license></image:license>
-        .replace(/<imagelicense>/g, '<image:license>')
-        .replace(/<\/imagelicense>/g, '</image:license>'),
+        // <imagegeolocation></imagegeolocation> ➡️ <image:geo_location></image:geo_location>
+        .replace(/(<\/?image)(geolocation)/g, '$1geo_location')
+        // <imageimage></imageimage> ➡️ <image:image></image:image>
+        .replace(/<\/?image/g, '$&:'),
   };
 }
 


### PR DESCRIPTION
Closes #107. 

Adds support, documentation, and tests for [Google Image Sitemaps](https://support.google.com/webmasters/answer/178636?hl=en).

You can now do this: 

```js
function hitToParams({
  objectID,
  modified,
  downloadsRatio,
  profilePic,
  coverPhoto,
  name,
}) {
  const url = ({ lang, objectID }) =>
    `https://${lang}.yoursite.com/${lang}/detail/${objectID}`;
  const loc = url({ lang: 'en', objectID });
  const lastmod = new Date().toISOString();
  const priority = Math.random();
  return {
    loc,
    lastmod,
    priority,
    images: [
      {
        loc: `https://media.yoursite.com/images/${profilePic}`,
        title: name,
      },
      {
        loc: `https://media.yoursite.com/images/${coverPhoto}`,
        title: name,
      },
    ],
    alternates: {
      languages: ['fr', 'pt-BR', 'zh-Hans'],
      hitToURL: lang => url({ lang, objectID }),
    },
  };
}
```

Valid keys for images: 

- `loc`
- `geo_location`
- `title`
- `caption`
- `license`