### PR TITLE
Fix: place the batch array into the function scope instead of the global scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ const { saveSiteMap } = require('./saveFiles');
 
 const CHUNK_SIZE = 50000;
 
-let batch = [];
-
 function init({
   algoliaConfig,
   params,
@@ -13,6 +11,7 @@ function init({
   outputFolder,
   hitToParams,
 }) {
+  let batch = [];
   const client = algoliasearch(algoliaConfig.appId, algoliaConfig.apiKey);
   const index = client.initIndex(algoliaConfig.indexName);
   const sitemaps = [];


### PR DESCRIPTION
When calling this module multiple times in a process, we found that each call was accumulating the data from the previous calls. This was because the `batch` variable was declared at the global scope, and was not being emptied on each execution.

This PR fixes the issue by moving the variable into the `init()` function's scope, where it is also initialized to an empty array.