### PR TITLE
fix: only continue browsing if cursor is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,8 +57,11 @@ function init({
       if (batch.length > CHUNK_SIZE) {
         await flush();
       }
-      ({ hits, cursor } = await index.browseFrom(cursor));
+      if (cursor) {
+        ({ hits, cursor } = await index.browseFrom(cursor));
+      }
     } while (cursor);
+
     await handleSitemap(batch);
     const sitemapIndex = createSitemapindex(sitemaps);
     await saveSiteMap({


### PR DESCRIPTION
it's possible that due to filters or a small index, there's only one page

fixes #215